### PR TITLE
Destructor fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,6 @@ if(NOT DEFINED CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
 endif()
 
 
-
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${Boost_INCLUDE_DIRS} ${MOOS_INCLUDE_DIRS})
 
 set(src
@@ -46,7 +44,6 @@ set_target_properties(pymoos
   PREFIX "")
   
   
-  
 file(GLOB ExampleFiles ${CMAKE_SOURCE_DIR}/Documentation/examples/*.py)
 add_custom_target(copy)
 get_target_property(pymoosLocation pymoos LOCATION)
@@ -56,13 +53,7 @@ foreach(ExampleFile ${ExampleFiles})
                      COMMAND ${CMAKE_COMMAND} -E
                          copy ${ExampleFile} ${pymoosDir})
 endforeach()
-add_dependencies(pymoos copy)  
-  
-
+add_dependencies(pymoos copy)    
 
 
 TARGET_LINK_LIBRARIES(pymoos ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${MOOS_LIBRARIES})
-
-
-                       
-                       

--- a/pyMOOS.cpp
+++ b/pyMOOS.cpp
@@ -45,6 +45,18 @@ class AsyncCommsWrapper : public MOOS::MOOSAsyncCommClient {
 private:
     typedef MOOSAsyncCommClient BASE;
 public:
+    
+    ~AsyncCommsWrapper(){
+        //AsyncCommsWrapper::Close(true);
+        //BASE::~BASE();
+          Py_BEGIN_ALLOW_THREADS
+          //PyGILState_STATE gstate = PyGILState_Ensure();
+          BASE::Close(true);
+          //PyGILState_Release(gstate);
+          Py_END_ALLOW_THREADS
+
+    }    
+
 
     bool Run(const std::string & sServer, int Port, const std::string & sMyName) {
         return BASE::Run(sServer, Port, sMyName, 0);//Comms Tick not used in Async version
@@ -81,13 +93,12 @@ public:
         return true;
     }
 
-    bool Close(bool nice)
-    {
-         Py_BEGIN_ALLOW_THREADS
-         //PyGILState_STATE gstate = PyGILState_Ensure();
-         BASE::Close(nice);
-         //PyGILState_Release(gstate);
-         Py_END_ALLOW_THREADS
+    bool Close(bool nice){
+        Py_BEGIN_ALLOW_THREADS
+        //PyGILState_STATE gstate = PyGILState_Ensure();
+        this->BASE::~BASE();
+        //PyGILState_Release(gstate);
+        Py_END_ALLOW_THREADS
     }
 
 


### PR DESCRIPTION
The remaining issue is when the function comms.close() is not called explicitly at the end of the example code tracker.py:

In this case the AsyncCommsWrapper destructor is called and this conduct us to the same problem where the application is stalled. 
In fact, BASE::close is called without the Py_BEGIN_ALLOW_THREADS  Py_END_ALLOW_THREADS macros. 

I've submitted a pull request with the fix. I've defined the destructor calling the Close() function. 
I've also introduced the closing_ used in on_mail() to avoid exceptions. I think  there is also a more correct solution. 