### PR TITLE
Fixed warning on compile and error message in callbackcomms example

### DIFF
--- a/Documentation/examples/callbackcomms.py
+++ b/Documentation/examples/callbackcomms.py
@@ -13,6 +13,7 @@ def c():
 
 def m():
     map(lambda msg: msg.trace(), comms.fetch() )
+    return True
         
 def main():
     

--- a/pyMOOS.cpp
+++ b/pyMOOS.cpp
@@ -85,13 +85,17 @@ public:
     }
 
     bool Close(bool nice){
+        bool bResult = false;
+
         Py_BEGIN_ALLOW_THREADS
         //PyGILState_STATE gstate = PyGILState_Ensure();
         closing_ = true;
-        BASE::Close(true);
+        bResult = BASE::Close(true);
         
         //PyGILState_Release(gstate);
         Py_END_ALLOW_THREADS
+        
+        return bResult;
     }
 
 
@@ -398,4 +402,3 @@ BOOST_PYTHON_MODULE(pymoos)
     bp::register_exception_translator<pyMOOSException>(&MOOSExceptionTranslator);
 
 }
-


### PR DESCRIPTION
When compiling the pyMOOS extension, a warning was given for a non-void function not returning anything.  This was the Close function and I added a result that is returned, which reflects what the C++ MOOS close function returns.

The callbackcomms.py example throws a warning/error message each time receives a message because the C++ callback is expecting something to be returned.  I added a return True and the message goes away.